### PR TITLE
fix(authentication-policy): omit empty method constraints

### DIFF
--- a/modules/authentication-policy/rules.tf
+++ b/modules/authentication-policy/rules.tf
@@ -119,7 +119,7 @@ resource "okta_app_signon_policy_rule" "this" {
               length(constraint.knowledge.excluded_authentication_methods) == 0,
             )
             types = [for type in constraint.knowledge.types : lower(type)]
-            authenticationMethods = [
+            authenticationMethods = length(constraint.knowledge.authentication_methods) == 0 ? null : [
               for authentication_method in constraint.knowledge.authentication_methods : {
                 for key, value in {
                   id     = authentication_method.id
@@ -129,7 +129,7 @@ resource "okta_app_signon_policy_rule" "this" {
                 if value != null
               }
             ]
-            excludedAuthenticationMethods = [
+            excludedAuthenticationMethods = length(constraint.knowledge.excluded_authentication_methods) == 0 ? null : [
               for authentication_method in constraint.knowledge.excluded_authentication_methods : {
                 for key, value in {
                   id     = authentication_method.id
@@ -154,7 +154,7 @@ resource "okta_app_signon_policy_rule" "this" {
             phishingResistant  = constraint.possession.phishing_resistant
             userPresence       = constraint.possession.user_presence
             userVerification   = constraint.possession.user_verification
-            authenticationMethods = [
+            authenticationMethods = length(constraint.possession.authentication_methods) == 0 ? null : [
               for authentication_method in constraint.possession.authentication_methods : {
                 for key, value in {
                   id     = authentication_method.id
@@ -164,7 +164,7 @@ resource "okta_app_signon_policy_rule" "this" {
                 if value != null
               }
             ]
-            excludedAuthenticationMethods = [
+            excludedAuthenticationMethods = length(constraint.possession.excluded_authentication_methods) == 0 ? null : [
               for authentication_method in constraint.possession.excluded_authentication_methods : {
                 for key, value in {
                   id     = authentication_method.id

--- a/modules/authentication-policy/tests/granular_authentication_methods.tftest.hcl
+++ b/modules/authentication-policy/tests/granular_authentication_methods.tftest.hcl
@@ -47,6 +47,22 @@ run "maps_granular_authentication_methods" {
     condition     = output.rules["default"].verification.constraints[1].knowledge.required == false
     error_message = "A constraint with excluded authentication methods must default required to false."
   }
+
+  assert {
+    condition = !contains(
+      keys(jsondecode(okta_app_signon_policy_rule.this["default"].constraints[0]).possession),
+      "excludedAuthenticationMethods",
+    )
+    error_message = "An empty possession excluded authentication methods list must be omitted from the API JSON."
+  }
+
+  assert {
+    condition = !contains(
+      keys(jsondecode(okta_app_signon_policy_rule.this["default"].constraints[1]).knowledge),
+      "authenticationMethods",
+    )
+    error_message = "An empty knowledge authentication methods list must be omitted from the API JSON."
+  }
 }
 
 run "rejects_required_with_excluded_authentication_methods" {


### PR DESCRIPTION
## What changed

- omit empty `authenticationMethods` and `excludedAuthenticationMethods` from knowledge constraint JSON
- omit the same empty fields from possession constraint JSON
- add raw resource JSON assertions that protect the omission behavior

## Root cause

The module encoded optional method lists as empty arrays. Okta normalizes empty arrays by omitting those properties from its response, so Terraform attempted to add them again on every plan.

## Impact

Existing non-empty allowlists and denylists are unchanged. Constraints without granular method lists now converge after apply instead of producing a perpetual in-place update.

## Checks

- `terraform -chdir=modules/authentication-policy validate -no-color`
- `terraform -chdir=modules/authentication-policy test -no-color` (9 passed)
- `tflint --chdir=modules/authentication-policy`
- `git diff --check`
